### PR TITLE
Added support for x86 compilation

### DIFF
--- a/Common/Common.h
+++ b/Common/Common.h
@@ -29,6 +29,47 @@ namespace PBD
 	using AlignedBox3r = Eigen::AlignedBox<Real, 3>;
 	using AngleAxisr = Eigen::AngleAxis<Real>;
 	using Quaternionr = Eigen::Quaternion<Real>;
+
+	//allocators to be used in STL collections containing Eigen structures
+	using Alloc_Vector2r = Eigen::aligned_allocator<Vector2r>;
+	using Alloc_Vector3r = Eigen::aligned_allocator<Vector2r>;
+	using Alloc_Vector4r = Eigen::aligned_allocator<Vector4r>;
+	using Alloc_Matrix2r = Eigen::aligned_allocator<Matrix2r>;
+	using Alloc_Matrix3r = Eigen::aligned_allocator<Matrix3r>;
+	using Alloc_Matrix4r = Eigen::aligned_allocator<Matrix4r>;
+	using Alloc_AlignedBox2r = Eigen::aligned_allocator<AlignedBox2r>;
+	using Alloc_AlignedBox3r = Eigen::aligned_allocator<AlignedBox3r>;
+	using Alloc_AngleAxisr = Eigen::aligned_allocator<AngleAxisr>;
+	using Alloc_Quaternionr = Eigen::aligned_allocator<Quaternionr>;
+
+#if EIGEN_ALIGN
+	#define PDB_MAKE_ALIGNED_OPERATOR_NEW EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+#if defined(WIN32) || defined(_WIN32) || defined(WIN64)	   
+#ifdef _DEBUG
+	// Enable memory leak detection for Eigen new
+	#undef PDB_MAKE_ALIGNED_OPERATOR_NEW
+	#define PDB_MAKE_ALIGNED_OPERATOR_NEW	EIGEN_MAKE_ALIGNED_OPERATOR_NEW \
+		void *operator new(size_t size, int const block_use, char const*  file_name, int const line_number) { \
+		\
+			return _aligned_malloc_dbg(size, 16, file_name, line_number); \
+		} \
+		void *operator new[](size_t size, int const block_use, char const*  file_name, int const line_number) { \
+			return operator new(size, block_use, file_name, line_number); \
+		}\
+		void operator delete(void* block, int const block_use, char const*  file_name, int const line_number) noexcept { \
+		\
+			return _aligned_free_dbg(block); \
+		} \
+		void operator delete[](void* block, int const block_use, char const*  file_name, int const line_number) noexcept { \
+			return operator delete(block, block_use, file_name, line_number); \
+		}	
+
+#endif
+#endif
+#else
+	#define PDB_MAKE_ALIGNED_OPERATOR_NEW
+#endif
 }
 
 #endif

--- a/Demos/Simulation/CollisionDetection.h
+++ b/Demos/Simulation/CollisionDetection.h
@@ -33,6 +33,9 @@ namespace PBD
 
 			virtual ~CollisionObject() {}
 			virtual int &getTypeId() const = 0;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			PDB_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct CollisionObjectWithoutGeometry : public CollisionObject

--- a/Demos/Simulation/Constraints.h
+++ b/Demos/Simulation/Constraints.h
@@ -27,6 +27,9 @@ namespace PBD
 		virtual bool updateConstraint(SimulationModel &model) { return true; };
 		virtual bool solvePositionConstraint(SimulationModel &model) { return true; };
 		virtual bool solveVelocityConstraint(SimulationModel &model) { return true; };
+
+	public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+		PDB_MAKE_ALIGNED_OPERATOR_NEW
 	};
 
 	class BallJoint : public Constraint

--- a/Demos/Simulation/RigidBody.h
+++ b/Demos/Simulation/RigidBody.h
@@ -539,6 +539,9 @@ namespace PBD
 			{
 				return m_geometry;
 			}
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			PDB_MAKE_ALIGNED_OPERATOR_NEW
 	};
 }
 

--- a/Demos/Utils/IndexedFaceMesh.h
+++ b/Demos/Utils/IndexedFaceMesh.h
@@ -95,14 +95,14 @@ namespace PBD
 
 	public:
 		typedef std::vector<unsigned int> Faces;
-		typedef std::vector<Vector3r> FaceNormals;
-		typedef std::vector<Vector3r> VertexNormals;
+		typedef std::vector<Vector3r, Alloc_Vector3r> FaceNormals;
+		typedef std::vector<Vector3r, Alloc_Vector3r> VertexNormals;
 		typedef std::vector<Face> FaceData;
 		typedef std::vector<Edge> Edges;
 		typedef std::vector<VertexFaces> VerticesFaces;
 		typedef std::vector<VertexEdges> VerticesEdges;
 		typedef std::vector<unsigned int> UVIndices;
-		typedef std::vector<Vector2r> UVs;
+		typedef std::vector<Vector2r, Alloc_Vector2r> UVs;
 
 	protected:
 		unsigned int m_numPoints;

--- a/Demos/Utils/OBJLoader.cpp
+++ b/Demos/Utils/OBJLoader.cpp
@@ -31,9 +31,9 @@ void OBJLoader::loadObj(const std::string &filename, VertexData &vertexData, Ind
 {
 	std::cout << "Loading " << filename << std::endl;
 
-	vector<Vector3r> positions;
-	vector<Vector2r> texcoords;
-	vector<Vector3r> normals;
+	vector<Vector3r, Alloc_Vector3r> positions;
+	vector<Vector2r, Alloc_Vector2r> texcoords;
+	vector<Vector3r, Alloc_Vector3r> normals;
 	vector<MeshFaceIndices> faces;
     
     ifstream filestream;

--- a/Demos/Utils/SceneLoader.h
+++ b/Demos/Utils/SceneLoader.h
@@ -34,6 +34,9 @@ namespace PBD
 			bool m_testMesh;
 			Vector3r m_collisionObjectScale;
 			boost::property_tree::ptree *pt;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			PDB_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct TriangleModelData
@@ -47,6 +50,9 @@ namespace PBD
 			Real m_restitutionCoeff;
 			Real m_frictionCoeff;
 			boost::property_tree::ptree *pt;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			PDB_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct TetModelData
@@ -63,12 +69,18 @@ namespace PBD
 			Real m_restitutionCoeff;
 			Real m_frictionCoeff;
 			boost::property_tree::ptree *pt;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct BallJointData
 		{
 			unsigned int m_bodyID[2];
 			Vector3r m_position;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			PDB_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct BallOnLineJointData
@@ -76,6 +88,9 @@ namespace PBD
 			unsigned int m_bodyID[2];
 			Vector3r m_position;
 			Vector3r m_axis;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			PDB_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct HingeJointData
@@ -83,6 +98,9 @@ namespace PBD
 			unsigned int m_bodyID[2];
 			Vector3r m_position;
 			Vector3r m_axis;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			PDB_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct UniversalJointData
@@ -90,6 +108,9 @@ namespace PBD
 			unsigned int m_bodyID[2];
 			Vector3r m_position;
 			Vector3r m_axis[2];
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			PDB_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct SliderJointData
@@ -97,6 +118,9 @@ namespace PBD
 			unsigned int m_bodyID[2];
 			Vector3r m_position;
 			Vector3r m_axis;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			PDB_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct RigidBodyParticleBallJointData
@@ -110,6 +134,9 @@ namespace PBD
 			Vector3r m_position;
 			Vector3r m_axis;
 			Real m_target;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			PDB_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct TargetVelocityMotorHingeJointData
@@ -118,6 +145,9 @@ namespace PBD
 			Vector3r m_position;
 			Vector3r m_axis;
 			Real m_target;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct TargetPositionMotorSliderJointData
@@ -126,6 +156,9 @@ namespace PBD
 			Vector3r m_position;
 			Vector3r m_axis;
 			Real m_target;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct TargetVelocityMotorSliderJointData
@@ -134,6 +167,9 @@ namespace PBD
 			Vector3r m_position;
 			Vector3r m_axis;
 			Real m_target;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		struct SceneData
@@ -187,6 +223,9 @@ namespace PBD
 			ObjectArray<TargetVelocityMotorHingeJointData> m_targetVelocityMotorHingeJointData;
 			ObjectArray<TargetPositionMotorSliderJointData> m_targetPositionMotorSliderJointData;
 			ObjectArray<TargetVelocityMotorSliderJointData> m_targetVelocityMotorSliderJointData;
+
+		public:	//BES: 23.8.2016 - make sure the class is aligned to 16 bytes even for x86 build
+			EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 		};
 
 		void readScene(const std::string &fileName, SceneData &sceneData);


### PR DESCRIPTION
Eigen assumes that structures are aligned to 16 bytes, which is  a requirement typically satisfied by a x64 compiler but not by a x86 compiler. As a result, the code compiles with VS 2015 with several warnings regarding wrong alignment, in runtime the debug code either displays an assert (see http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html) or simply crashes.

This commit adds custom operators new/delete to various classes working with Eigen structures to guarantee the memory alignment according to the recommendation provided by Eigen. I tried to minimize the number of changes. 

I checked that all demos run smoothly without any problem.