### PR TITLE
Fix pointer aliasing in kdtree

### DIFF
--- a/Demos/Simulation/kdTree.inl
+++ b/Demos/Simulation/kdTree.inl
@@ -1,5 +1,6 @@
 
 #include "BoundingSphere.h"
+#include <cstring>
 #include "omp.h"
 
 template<typename HullType> void
@@ -127,8 +128,10 @@ KDTree<HullType>::traverse_breadth_first_parallel(TraversalPredicate pred,
 #endif
 
 	// compute ceiling of Log2
-	Real d = maxThreads - 1;
-	const unsigned int targetDepth = (*reinterpret_cast<long long*>(&d) >> 52) - 1022;
+	// assuming double and long long have the same size.
+	double d = maxThreads - 1;
+	long long ll;  memcpy( &ll, &d, sizeof(d));
+	const unsigned int targetDepth = (ll >> 52) - 1022ll;
 	
 	traverse_breadth_first(
 		[&start_nodes, &maxThreads, &targetDepth](unsigned int node_index, unsigned int depth)


### PR DESCRIPTION
This commit addresses two problems related the the fast log2 computation in the kdtree :
* The code was written with Real = double in mind which may not always be the case. The variable is now explicitly set to double.
* GCC issues a warning for the reinterpret-cast when compiling with -fstrict-aliasing. The portable solution here is to use memcpy (according to http://dbp-consulting.com/tutorials/StrictAliasing.html) which compilers will optimize.