### PR TITLE
Fix linker errors for RelWithDebInfo and MinSizeRel

### DIFF
--- a/Demos/BarDemo/CMakeLists.txt
+++ b/Demos/BarDemo/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(BarDemo
 	  CMakeLists.txt
 )
 
-add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC)
+add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC -DFREEGLUT_LIB_PRAGMAS=0)
 
 find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )

--- a/Demos/ClothDemo/CMakeLists.txt
+++ b/Demos/ClothDemo/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(ClothDemo
 	  CMakeLists.txt
 )
 
-add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC)
+add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC -DFREEGLUT_LIB_PRAGMAS=0)
 
 find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )

--- a/Demos/CosseratRodsDemo/CMakeLists.txt
+++ b/Demos/CosseratRodsDemo/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(CosseratRodsDemo
 	  CMakeLists.txt
 )
 
-add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC)
+add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC -DFREEGLUT_LIB_PRAGMAS=0)
 
 find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )

--- a/Demos/CouplingDemos/CMakeLists.txt
+++ b/Demos/CouplingDemos/CMakeLists.txt
@@ -32,7 +32,7 @@ add_dependencies(RigidBodyClothCouplingDemo ${SIMULATION_DEPENDENCIES})
 target_link_libraries(RigidBodyClothCouplingDemo ${SIMULATION_LINK_LIBRARIES})
 
 
-add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC)
+add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC -DFREEGLUT_LIB_PRAGMAS=0)
 find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )
 include_directories(${PROJECT_PATH}/extern/freeglut/include)

--- a/Demos/DistanceFieldDemos/CMakeLists.txt
+++ b/Demos/DistanceFieldDemos/CMakeLists.txt
@@ -66,7 +66,7 @@ add_dependencies(RigidBodyCollisionDemo ${SIMULATION_DEPENDENCIES})
 target_link_libraries(RigidBodyCollisionDemo ${SIMULATION_LINK_LIBRARIES})
 
 
-add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC)
+add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC -DFREEGLUT_LIB_PRAGMAS=0)
 find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )
 include_directories(${PROJECT_PATH}/extern/freeglut/include)

--- a/Demos/FluidDemo/CMakeLists.txt
+++ b/Demos/FluidDemo/CMakeLists.txt
@@ -29,7 +29,7 @@ add_executable(FluidDemo
 	  CMakeLists.txt
 )
 
-add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC)
+add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC -DFREEGLUT_LIB_PRAGMAS=0)
 
 find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )

--- a/Demos/GenericConstraintsDemos/CMakeLists.txt
+++ b/Demos/GenericConstraintsDemos/CMakeLists.txt
@@ -29,7 +29,7 @@ add_executable(GenericParticleConstraintsDemo
 	  CMakeLists.txt
 )
 
-add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC)
+add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC -DFREEGLUT_LIB_PRAGMAS=0)
 
 find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )

--- a/Demos/PositionBasedElasticRodsDemo/CMakeLists.txt
+++ b/Demos/PositionBasedElasticRodsDemo/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable(ElasticRodDemo
 	  CMakeLists.txt
 )
 
-add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC)
+add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC -DFREEGLUT_LIB_PRAGMAS=0)
 
 find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )

--- a/Demos/RigidBodyDemos/CMakeLists.txt
+++ b/Demos/RigidBodyDemos/CMakeLists.txt
@@ -47,7 +47,7 @@ set_target_properties(JointDemo PROPERTIES MINSIZEREL_POSTFIX ${CMAKE_MINSIZEREL
 add_dependencies(JointDemo ${SIMULATION_DEPENDENCIES})
 target_link_libraries(JointDemo ${SIMULATION_LINK_LIBRARIES})
 
-add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC)
+add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC -DFREEGLUT_LIB_PRAGMAS=0)
 find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )
 include_directories(${PROJECT_PATH}/extern/freeglut/include)

--- a/Demos/SceneLoaderDemo/CMakeLists.txt
+++ b/Demos/SceneLoaderDemo/CMakeLists.txt
@@ -32,7 +32,7 @@ add_dependencies(SceneLoaderDemo ${SIMULATION_DEPENDENCIES})
 target_link_libraries(SceneLoaderDemo ${SIMULATION_LINK_LIBRARIES})
 
 
-add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC)
+add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC -DFREEGLUT_LIB_PRAGMAS=0)
 find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )
 include_directories(${PROJECT_PATH}/extern/freeglut/include)


### PR DESCRIPTION
Although the freeglut static library file is specified from CMake, freeglut_std.h is still trying to specify a library file from MSVC's pragma.

This PR fixes the issue by suppressing the use of MSVC's pragma through a preprocessor definition.