### PR TITLE
Compile for OSX (requires libomp)

### DIFF
--- a/CMake/Common.cmake
+++ b/CMake/Common.cmake
@@ -31,9 +31,6 @@ if(APPLE)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
     # Set compiler flags for "release"
     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -Xpreprocessor -fopenmp")
-    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "-lomp")
-    set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "-lomp")
-    set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "-lomp")
 endif()
 
 set (CMAKE_CXX_STANDARD 11)

--- a/CMake/Common.cmake
+++ b/CMake/Common.cmake
@@ -26,7 +26,14 @@ if (UNIX)
 endif (UNIX)
 
 if(APPLE)
+    set(CMAKE_USE_RELATIVE_PATHS "1")
     set(CMAKE_MACOSX_RPATH 1)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
+    # Set compiler flags for "release"
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -Xpreprocessor -fopenmp")
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "-lomp")
+    set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "-lomp")
+    set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "-lomp")
 endif()
 
 set (CMAKE_CXX_STANDARD 11)

--- a/Demos/Simulation/CMakeLists.txt
+++ b/Demos/Simulation/CMakeLists.txt
@@ -49,7 +49,11 @@ find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )
 include_directories(${PROJECT_PATH}/extern/Miniball)
 
-target_link_libraries(Simulation PositionBasedDynamics)
+set(SIMULATION_LIBRARIES PositionBasedDynamics)
+if(APPLE)
+	set(SIMULATION_LIBRARIES ${SIMULATION_LIBRARIES} omp)
+endif()
+target_link_libraries(Simulation ${SIMULATION_LIBRARIES})
 
 
 install(TARGETS Simulation

--- a/Demos/Simulation/CMakeLists.txt
+++ b/Demos/Simulation/CMakeLists.txt
@@ -49,11 +49,7 @@ find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )
 include_directories(${PROJECT_PATH}/extern/Miniball)
 
-set(SIMULATION_LIBRARIES PositionBasedDynamics)
-if(APPLE)
-	set(SIMULATION_LIBRARIES ${SIMULATION_LIBRARIES} omp)
-endif()
-target_link_libraries(Simulation ${SIMULATION_LIBRARIES})
+target_link_libraries(Simulation PositionBasedDynamics)
 
 
 install(TARGETS Simulation

--- a/Demos/Utils/FileSystem.h
+++ b/Demos/Utils/FileSystem.h
@@ -5,13 +5,22 @@
 #include "StringTools.h"
 #include "Logger.h"
 #include "extern/md5/md5.h"
+
 #if WIN32
+
 #include <direct.h>
 #define NOMINMAX
 #include "windows.h"
+
 #else
+
 #include <sys/stat.h>
 #include <unistd.h>
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif // __APPLE__
+
 #endif
 
 namespace PBD
@@ -205,8 +214,15 @@ namespace PBD
 		static std::string getProgramPath()
 		{
 			char buffer[1000];
-#ifdef WIN32	
+#ifdef WIN32
 			GetModuleFileName(NULL, buffer, 1000);
+#elif __APPLE__
+            char path[4192];
+			uint32_t size = sizeof(path);
+			if (_NSGetExecutablePath(path, &size) == 0)
+			{
+				strncpy(buffer, path, sizeof(buffer));
+			}
 #else
 			char szTmp[32];
 			sprintf(szTmp, "/proc/%d/exe", getpid());

--- a/Demos/Visualization/MiniGL.cpp
+++ b/Demos/Visualization/MiniGL.cpp
@@ -1062,7 +1062,11 @@ void MiniGL::breakPointMainLoop()
 		m_breakPointLoop = true;
 		while (m_breakPointLoop)
 		{
+#ifdef __APPLE__
+            // not available on OSX system GLUT
+#else
 			glutMainLoopEvent();
+#endif
 		}
 	}
 }

--- a/PositionBasedDynamics/CMakeLists.txt
+++ b/PositionBasedDynamics/CMakeLists.txt
@@ -21,6 +21,9 @@ add_library(PositionBasedDynamics
 )
 
 find_package( Eigen3 REQUIRED )
+if(APPLE)
+	target_link_libraries(PositionBasedDynamics omp)
+endif()
 include_directories( ${EIGEN3_INCLUDE_DIR} )
 
 install(TARGETS PositionBasedDynamics


### PR DESCRIPTION
Support for building on OSX. 

Wrangle: needs a `libomp.dylib`. Xcode ships with clang that supports OpenMP (`-Xpreprocessor -fopenmp`) but you still need to manually build `libomp.dylib` and place it somewhere in search paths. Ref https://stackoverflow.com/a/47230419/42961 . To build `libomp` and install headers and libs in `/usr/local`, do this:

    $ cd /tmp
    $ svn co http://llvm.org/svn/llvm-project/openmp/trunk libomp
    $ cd libomp
    $ mkdir build && cd build
    $ cmake -DCMAKE_INSTALL_PREFIX=/usr/local ..
    $ make && make install